### PR TITLE
Update .gitignore for BetterDiscord files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-betterdiscord.asar
-addon-store.json
-misc.json
+data/
+plugins/*.config

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 data/
-plugins/*.config


### PR DESCRIPTION
Exclude additional plugin configuration files and include necessary files for BetterDiscord in the .gitignore.